### PR TITLE
fix: resolve input lockup after first chat message

### DIFF
--- a/app/services/dify_service.py
+++ b/app/services/dify_service.py
@@ -46,6 +46,13 @@ async def send_message_stream(
                             yield json.loads(data_str)
                         except json.JSONDecodeError:
                             continue
+            # Process any remaining data in buffer after stream ends
+            buffer = buffer.strip()
+            if buffer.startswith("data: "):
+                try:
+                    yield json.loads(buffer[6:])
+                except json.JSONDecodeError:
+                    pass
 
 
 async def send_message(

--- a/miniprogram/utils/api.js
+++ b/miniprogram/utils/api.js
@@ -31,25 +31,34 @@ function sendMessage(message, conversationId, onChunk, onDone, onError) {
         return;
       }
       // Parse SSE data from response
-      const text = res.data;
-      if (typeof text === 'string') {
-        const lines = text.split('\n');
-        for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            try {
-              const data = JSON.parse(line.slice(6));
-              if (data.type === 'message') {
-                onChunk(data.content);
-              } else if (data.type === 'done') {
-                onDone({ conversationId: data.conversation_id });
-              } else if (data.type === 'error') {
-                onError(data.content);
-              }
-            } catch (e) {
-              // skip invalid JSON
+      const text = typeof res.data === 'string' ? res.data : JSON.stringify(res.data);
+      const lines = text.split('\n');
+      let gotDone = false;
+      let lastConversationId = null;
+
+      for (const line of lines) {
+        if (line.startsWith('data: ')) {
+          try {
+            const data = JSON.parse(line.slice(6));
+            if (data.type === 'message') {
+              onChunk(data.content);
+            } else if (data.type === 'done') {
+              gotDone = true;
+              lastConversationId = data.conversation_id;
+              onDone({ conversationId: data.conversation_id });
+            } else if (data.type === 'error') {
+              onError(data.content);
+              return;
             }
+          } catch (e) {
+            // skip invalid JSON
           }
         }
+      }
+
+      // Fallback: if we received data but no done event, still finalize
+      if (!gotDone) {
+        onDone({ conversationId: lastConversationId });
       }
     },
     fail(err) {


### PR DESCRIPTION
- Backend: process remaining SSE buffer after Dify stream ends, ensuring message_end event is not lost when it lacks a trailing newline
- Frontend: add fallback to finalize chat state even if done event is missing, preventing isTyping from staying true and locking the input

https://claude.ai/code/session_01VV2PZ9YFkM34yzSjoLHAoa