### PR TITLE
fix: use onChunkReceived for real SSE streaming in frontend

### DIFF
--- a/miniprogram/utils/api.js
+++ b/miniprogram/utils/api.js
@@ -9,10 +9,15 @@ const app = getApp();
  * @param {function} onError - Called on error
  */
 function sendMessage(message, conversationId, onChunk, onDone, onError) {
+  let buffer = '';
+  let gotDone = false;
+  let statusCode = 0;
+
   const requestTask = wx.request({
     url: `${app.globalData.baseUrl}/api/chat`,
     method: 'POST',
     enableChunkedTransfer: true,
+    responseType: 'text',
     header: {
       'Authorization': `Bearer ${app.globalData.token}`,
       'Content-Type': 'application/json',
@@ -22,6 +27,7 @@ function sendMessage(message, conversationId, onChunk, onDone, onError) {
       conversation_id: conversationId,
     },
     success(res) {
+      statusCode = res.statusCode;
       if (res.statusCode === 403) {
         onError('对话次数已用完，请充值后继续使用。');
         return;
@@ -30,40 +36,61 @@ function sendMessage(message, conversationId, onChunk, onDone, onError) {
         onError(res.data.detail || '请求失败');
         return;
       }
-      // Parse SSE data from response
-      const text = typeof res.data === 'string' ? res.data : JSON.stringify(res.data);
-      const lines = text.split('\n');
-      let gotDone = false;
-      let lastConversationId = null;
-
-      for (const line of lines) {
-        if (line.startsWith('data: ')) {
-          try {
-            const data = JSON.parse(line.slice(6));
-            if (data.type === 'message') {
-              onChunk(data.content);
-            } else if (data.type === 'done') {
-              gotDone = true;
-              lastConversationId = data.conversation_id;
-              onDone({ conversationId: data.conversation_id });
-            } else if (data.type === 'error') {
-              onError(data.content);
-              return;
-            }
-          } catch (e) {
-            // skip invalid JSON
-          }
-        }
+      // Process any remaining data in buffer
+      if (res.data) {
+        const text = typeof res.data === 'string' ? res.data : '';
+        processSSEBuffer(text);
       }
-
-      // Fallback: if we received data but no done event, still finalize
+      // Ensure we always finalize
       if (!gotDone) {
-        onDone({ conversationId: lastConversationId });
+        onDone({ conversationId: null });
       }
     },
     fail(err) {
-      onError('网络请求失败，请检查网络连接。');
+      if (!gotDone) {
+        onError('网络请求失败，请检查网络连接。');
+      }
     },
+  });
+
+  function processSSEBuffer(text) {
+    buffer += text;
+    const parts = buffer.split('\n');
+    // Keep the last incomplete line in buffer
+    buffer = parts.pop() || '';
+
+    for (const line of parts) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('data: ')) {
+        try {
+          const data = JSON.parse(trimmed.slice(6));
+          if (data.type === 'message') {
+            onChunk(data.content);
+          } else if (data.type === 'done') {
+            gotDone = true;
+            onDone({ conversationId: data.conversation_id });
+          } else if (data.type === 'error') {
+            gotDone = true;
+            onError(data.content);
+          }
+        } catch (e) {
+          // skip invalid JSON
+        }
+      }
+    }
+  }
+
+  // Handle real-time chunks as they arrive
+  requestTask.onChunkReceived(function (res) {
+    if (res.data) {
+      let text;
+      if (res.data instanceof ArrayBuffer) {
+        text = String.fromCharCode.apply(null, new Uint8Array(res.data));
+      } else {
+        text = String(res.data);
+      }
+      processSSEBuffer(text);
+    }
   });
 
   return requestTask;

--- a/tests/test_chat_sse.py
+++ b/tests/test_chat_sse.py
@@ -1,0 +1,179 @@
+"""Test that the /api/chat endpoint returns proper SSE events,
+including a 'done' event, and that a second message in the same
+conversation also works correctly."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.auth import create_token
+from app.db.database import Base, SessionLocal, User, engine
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    """Create a fresh in-memory DB for each test."""
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    # Seed a test user
+    user = User(openid="test-openid", free_quota=10)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    db.close()
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def _make_token(user_id: int = 1) -> str:
+    return create_token(user_id)
+
+
+# ---------------------------------------------------------------------------
+# Fake Dify stream generator
+# ---------------------------------------------------------------------------
+
+async def fake_dify_stream(query, user_id, conversation_id=""):
+    """Simulate Dify SSE events: several message chunks + message_end."""
+    chunks = ["Hello", ", this is ", "a test reply."]
+    for chunk in chunks:
+        yield {"event": "message", "answer": chunk}
+        await asyncio.sleep(0)  # let the event loop tick
+    yield {
+        "event": "message_end",
+        "conversation_id": "dify-conv-abc123",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def parse_sse_events(body: str) -> list[dict]:
+    """Parse SSE text into a list of data dicts."""
+    events = []
+    for line in body.split("\n"):
+        line = line.strip()
+        if line.startswith("data: "):
+            try:
+                events.append(json.loads(line[6:]))
+            except json.JSONDecodeError:
+                pass
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@patch("app.api.chat.dify_service.send_message_stream", side_effect=fake_dify_stream)
+async def test_first_message_returns_done_event(mock_dify):
+    """First chat message should return message chunks + a done event."""
+    from app.main import app
+
+    token = _make_token()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200
+    events = parse_sse_events(resp.text)
+
+    # Should have message events + exactly one done event
+    msg_events = [e for e in events if e.get("type") == "message"]
+    done_events = [e for e in events if e.get("type") == "done"]
+
+    assert len(msg_events) >= 1, f"Expected message events, got: {events}"
+    assert len(done_events) == 1, f"Expected exactly 1 done event, got: {events}"
+
+    # done event should include a conversation_id
+    assert done_events[0]["conversation_id"] is not None
+
+    # Concatenated content should match
+    full_text = "".join(e["content"] for e in msg_events)
+    assert full_text == "Hello, this is a test reply."
+
+
+@pytest.mark.asyncio
+@patch("app.api.chat.dify_service.send_message_stream", side_effect=fake_dify_stream)
+async def test_second_message_works(mock_dify):
+    """After a first message, sending a second message in the same
+    conversation should succeed and also return a done event."""
+    from app.main import app
+
+    token = _make_token()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        # First message
+        resp1 = await client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp1.status_code == 200
+        events1 = parse_sse_events(resp1.text)
+        done1 = [e for e in events1 if e.get("type") == "done"][0]
+        conv_id = done1["conversation_id"]
+
+        # Second message using the conversation_id from the first
+        resp2 = await client.post(
+            "/api/chat",
+            json={"message": "next question", "conversation_id": conv_id},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp2.status_code == 200
+    events2 = parse_sse_events(resp2.text)
+
+    msg_events2 = [e for e in events2 if e.get("type") == "message"]
+    done_events2 = [e for e in events2 if e.get("type") == "done"]
+
+    assert len(msg_events2) >= 1, f"Second message had no message events: {events2}"
+    assert len(done_events2) == 1, f"Second message missing done event: {events2}"
+
+    # Verify mock was called with the Dify conversation_id for continuity
+    second_call = mock_dify.call_args_list[1]
+    assert second_call.kwargs.get("conversation_id") == "dify-conv-abc123" or \
+           second_call[1].get("conversation_id") == "dify-conv-abc123", \
+        f"Second call should pass Dify conversation_id, got: {second_call}"
+
+
+@pytest.mark.asyncio
+@patch("app.api.chat.dify_service.send_message_stream", side_effect=fake_dify_stream)
+async def test_sse_format_has_proper_newlines(mock_dify):
+    """Each SSE data line should be followed by double newlines,
+    so the frontend can split and parse them correctly."""
+    from app.main import app
+
+    token = _make_token()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/api/chat",
+            json={"message": "hello"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    body = resp.text
+    # Each "data: " line should be followed by "\n\n"
+    import re
+    data_lines = re.findall(r"data: .+", body)
+    assert len(data_lines) >= 2, f"Expected multiple data lines, got: {data_lines}"
+
+    # Verify double newline separators exist
+    assert "\n\n" in body, "SSE events should be separated by double newlines"


### PR DESCRIPTION
The input lockup after the first message was caused by enableChunkedTransfer not working correctly with the success-only callback approach. With chunked transfer enabled, wx.request may deliver data via onChunkReceived rather than in the success callback's res.data, causing onDone to never fire and isTyping to stay true.

Changes:
- Frontend: rewrite sendMessage to use requestTask.onChunkReceived() for real-time SSE chunk processing, with success callback as fallback
- Add backend tests verifying SSE format, done event, and multi-message flow

https://claude.ai/code/session_01VV2PZ9YFkM34yzSjoLHAoa